### PR TITLE
Adding jetty-maven-plugin and a short project description including urls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,16 @@
     <artifactId>jersey-swagger-ui-example</artifactId>
     <packaging>war</packaging>
     <version>1.0.0</version>
+
+    <description>
+        Example on how to co host Swagger UI in a Jersey application.
+        mvn jetty:run-war
+        REST-service: http://localhost:8080/api/hello
+        OpenApi json format: http://localhost:8080/api/openapi.json
+        OpenApi yaml format: http://localhost:8080/api/openapi.yaml
+        SwaggerUI: http://localhost:8080/swagger-ui/
+    </description>
+
     <properties>
         <!-- Build plugins -->
         <java.version>1.8</java.version>
@@ -149,6 +159,11 @@
                         </replacement>
                     </replacements>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>9.4.20.v20190813</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Thanks for a very nice and clean example. I found it very useful. It was even more useful with the jetty-plugin so it could be run directly from the cmdline. Also added the urls in the description part of the pom.

Add it to your project if you feel like it.

Thanks anyways.

Soda